### PR TITLE
[modified MaterialActionBar to support native  user control of winform]

### DIFF
--- a/MaterialWinforms/Controls/MaterialActionBar.cs
+++ b/MaterialWinforms/Controls/MaterialActionBar.cs
@@ -182,9 +182,11 @@ namespace MaterialWinforms.Controls
         {
             base.OnParentChanged(e);
             Dock = DockStyle.Top;
+            if(Parent is MaterialForm) { 
             DrawBackArrow = ((MaterialForm)Parent).SideDrawer != null;
             if(DrawBackArrow)
                 DrawBackArrow = ((MaterialForm)Parent).SideDrawer.SideDrawerFixiert;
+            }
             Refresh();
         }
 
@@ -455,7 +457,7 @@ namespace MaterialWinforms.Controls
                 }
 
 
-                MaterialForm objParent = (MaterialForm)Parent;
+                Control objParent = (Control)Parent;
                 if (DrawBackArrow)
                 {
 


### PR DESCRIPTION
When Adding MaterialActionBar, It would only support Parent which were of MaterialForm Type. Have modified the Code so that it will support any Parent control including Native User Controls of winforms. 